### PR TITLE
fix: add missing lock file entry for bun.lock

### DIFF
--- a/src/helpers/detect.ts
+++ b/src/helpers/detect.ts
@@ -17,6 +17,7 @@ export const agents = AGENTS;
 // the order here matters, more specific one comes first
 export const LOCKS: Record<string, Agent> = {
   'bun.lockb': 'bun',
+  "bun.lock": 'bun',
   'npm-shrinkwrap.json': 'npm',
   'package-lock.json': 'npm',
   'pnpm-lock.yaml': 'pnpm',

--- a/src/helpers/detect.ts
+++ b/src/helpers/detect.ts
@@ -16,8 +16,8 @@ export const agents = AGENTS;
 
 // the order here matters, more specific one comes first
 export const LOCKS: Record<string, Agent> = {
+  'bun.lock': 'bun',
   'bun.lockb': 'bun',
-  "bun.lock": 'bun',
   'npm-shrinkwrap.json': 'npm',
   'package-lock.json': 'npm',
   'pnpm-lock.yaml': 'pnpm',


### PR DESCRIPTION
## 📝 Description
Bun has recently changed to using a `bun.lock` file as supposed to the `bun.lockb` file. The CLI doesn't check for this file, thus making Bun undetected.

## ✅ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
