### PR TITLE
fix: add cache directory check before reading cache data (issue #161)

### DIFF
--- a/src/scripts/cache/cache.ts
+++ b/src/scripts/cache/cache.ts
@@ -31,6 +31,9 @@ export function initCache(_noCache = noCache) {
 }
 
 export function getCacheData(): CacheData {
+  if (!existsSync(CACHE_DIR)) {
+    initCache();
+  }
   const data = readFileSync(CACHE_PATH, 'utf8');
 
   return JSON.parse(data);


### PR DESCRIPTION
## 📝 Description
Fixed CLI crash on startup. The issue was caused by missing cache directory check before reading cache data. Added cache directory existence check before reading data.

Fixes #161

## ✅ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)